### PR TITLE
Update default.json with best practices and new rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,11 +1,18 @@
 {
   "description": "Default preset for use with Open Collective repos",
   "extends": [
-    "config:base",
+    "config:best-practices",
     ":preserveSemverRanges"
   ],
   "schedule": [
     "every weekday after 2:00 am before 6:00 am",
     "every weekend"
+  ],
+  "packageRules": [
+    {
+      "description": "Our own packages are trusted, update immediately without any delay",
+      "matchPackageNames": ["@opencollective/*"],
+      "minimumReleaseAge": null
+    }
   ]
 }


### PR DESCRIPTION
See https://docs.renovatebot.com/upgrade-best-practices/

This is mostly to enforce the minimum release age to mitigate supply chain attacks.